### PR TITLE
feat: add hasSVGIcons function to check existing SVG files

### DIFF
--- a/generateSprites.js
+++ b/generateSprites.js
@@ -65,3 +65,21 @@ export const generateSprites = async (options) => {
 
   console.log("[✅] Sprites regenerated.");
 };
+
+export const hasSVGIcons = async (srcDir) => {
+  try {
+    const folders = await getIconFolders(srcDir);
+
+    const results = await Promise.all(
+      folders.map(async (folder) => {
+        const files = await readdir(path.join(srcDir, folder.name));
+        return files.some(f => f.endsWith('.svg'));
+      })
+    );
+
+    return results.includes(true);
+  } catch (err) {
+    console.error(`[❌] Error reading SVG icons in ${srcDir}:`, err);
+    return false;
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { join, resolve } from "node:path";
 import { cwd } from "node:process";
 
-import { generateSprites } from "./generateSprites.js";
+import { generateSprites, hasSVGIcons } from "./generateSprites.js";
 
 const DEFAULT_SRC_DIR = "/src/icons/";
 const DEFAULT_DEST_DIR = "/public/assets/icons/";
@@ -15,10 +15,17 @@ const watchSpritesPlugin = (initialOptions = {}) => {
 
   return {
     name: "watch-sprites",
-    configureServer(server) {
+    async configureServer(server) {
       console.log("[🧪] Plugin watch-sprites enabled");
       const iconsPath = resolve(options.srcDir);
       server.watcher.add(iconsPath);
+
+      if (await hasSVGIcons(options.srcDir)) {
+        console.log(`[🎨] Icon modified: ${iconsPath}`);
+        generateSprites(options);
+      } else {
+        console.log(`[❌] No icons found in: ${iconsPath}`);
+      }
 
       server.watcher.on("change", (filePath) => {
         if (filePath.startsWith(iconsPath)) {


### PR DESCRIPTION
Este pull request mejora la funcionalidad del sistema de generación de sprites al introducir una utilidad para verificar la existencia de iconos SVG.

### Nueva funcionalidad:

* Se agregó la función `hasSVGIcons` en `generateSprites.js` para comprobar si un directorio fuente ya contiene iconos SVG. Esto incluye el manejo de errores al leer el directorio.

### Integración con el plugin de vigilancia:

* Se actualizó `index.js` para importar la nueva función `hasSVGIcons` junto con `generateSprites`.
* Se modificó el método `configureServer` del `watchSpritesPlugin` en `index.js` para usar `hasSVGIcons` al verificar iconos SVG antes de regenerar los sprites, con registros apropiados para escenarios de éxito o error.