### PR TITLE
fix(types): add types definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+import type { Config as SvgSpriteConfig } from "@types/svg-sprite";
+
+/**
+ * Options for the vite-plugin-supersvg plugin.
+ * @property srcDir Source directory for SVG icons.
+ * @property destDir Destination directory for generated sprites.
+ * @property config Additional options for svg-sprite.
+ */
+export interface SupersvgPluginOptions {
+  /** Source directory for SVG icons. */
+  srcDir?: string;
+  /** Destination directory for generated sprites. */
+  destDir?: string;
+  /** Whether to generate sprites lazily (on demand). */
+  lazy?: boolean;
+  /** Additional options for svg-sprite. */
+  config?: SvgSpriteConfig;
+}
+
+/**
+ * Creates sprites for your SVG icon files.
+ * @param options Options for the plugin.
+ */
+declare function supersvgPlugin(options?: SupersvgPluginOptions);
+
+export default supersvgPlugin;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "0.0.6",
   "description": "A Vite plugin to create SVG sprites for easy use.",
   "main": "index.js",
+  "types": "index.d.ts",
   "type": "module",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "generateSprites.js"
+  ],
   "scripts": {},
   "keywords": [
     "svg",
@@ -16,6 +22,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.12.1",
   "dependencies": {
+    "@types/svg-sprite": "^0.0.39",
     "svg-sprite": "^2.0.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/svg-sprite':
+        specifier: ^0.0.39
+        version: 0.0.39
       svg-sprite:
         specifier: ^2.0.4
         version: 2.0.4
@@ -101,8 +104,20 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@types/expect@1.20.4':
+    resolution: {integrity: sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==}
+
+  '@types/node@24.0.3':
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
+
+  '@types/svg-sprite@0.0.39':
+    resolution: {integrity: sha512-6zpek4v8Ch8iZ9HnXlla8Zqt9bPi9MQZt3IAI6Xqn1Ts3xOUo2nX2qRGu/tfxCeNoQ925PMI+t6z6eiJh/RNzQ==}
+
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/vinyl@2.0.12':
+    resolution: {integrity: sha512-Sr2fYMBUVGYq8kj3UthXFAu5UN6ZW+rYr4NACjZQJvHvj+c8lYv0CahmZ2P/r7iUkN44gGUBwqxZkrKXYPb7cw==}
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -391,6 +406,9 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -492,7 +510,24 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@types/expect@1.20.4': {}
+
+  '@types/node@24.0.3':
+    dependencies:
+      undici-types: 7.8.0
+
+  '@types/svg-sprite@0.0.39':
+    dependencies:
+      '@types/node': 24.0.3
+      '@types/vinyl': 2.0.12
+      winston: 3.17.0
+
   '@types/triple-beam@1.3.5': {}
+
+  '@types/vinyl@2.0.12':
+    dependencies:
+      '@types/expect': 1.20.4
+      '@types/node': 24.0.3
 
   '@xmldom/xmldom@0.8.10': {}
 
@@ -785,6 +820,8 @@ snapshots:
   text-hex@1.0.0: {}
 
   triple-beam@1.4.1: {}
+
+  undici-types@7.8.0: {}
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
Este pull request añade definiciones de tipos y para mejorar el autocompletado de opciones del plugin.

### Actualizaciones:

* Se añadió un nuevo campo `types` apuntando a `index.d.ts` y se incluyó `@types/svg-sprite` como dependencia para proporcionar definiciones de las opciones de la librería `svg-sprite`. También se actualizó el campo `files` para incluir `index.js`, `index.d.ts` y `generateSprites.js`. [[1]](https://github.com/ManzDev/vite-plugin-supersvg/compare/main...felixicaza:fix/definitions?expand=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-R12) [[2]](https://github.com/ManzDev/vite-plugin-supersvg/compare/main...felixicaza:fix/definitions?expand=1#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R25)

### Vista previa:

https://github.com/user-attachments/assets/8ade720d-3c25-43b1-90b4-f8a0e7c92fdf
